### PR TITLE
[Port] 26.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,20 +6,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@v6
       - name: setup jdk
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'microsoft'
       - name: make gradle wrapper executable
         run: chmod +x ./gradlew
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Artifacts
           path: build/libs/

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id "fabric-loom" version "1.16-SNAPSHOT"
+	id "net.fabricmc.fabric-loom" version "1.16-SNAPSHOT"
 	id "io.github.p03w.machete" version "1.2.0"
 }
 
@@ -10,9 +10,8 @@ repositories {}
 
 dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
-    mappings loom.officialMojangMappings()
-    modImplementation "net.fabricmc:fabric-loader:${project.fabric_loader}"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api}"
+    implementation "net.fabricmc:fabric-loader:${project.fabric_loader}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api}"
 }
 
 processResources {
@@ -24,11 +23,11 @@ processResources {
 
 tasks.withType(JavaCompile).configureEach {
     it.options.encoding = "UTF-8"
-    it.options.release = 21
+    it.options.release = 25
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
     withSourcesJar()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,11 @@ org.gradle.jvmargs = -Xmx1G
 org.gradle.parallel = true
 
 # Mod Properties
-mod_version = 0.3.0+1.21.11
+mod_version = 0.3.0+26.1
 maven_group = ru.pinkgoosik
 archives_base_name = better-end-sky
 
 # Dependencies | Check these on https://fabricmc.net/develop
-minecraft_version = 1.21.11
+minecraft_version = 26.1
 fabric_loader = 0.19.2
-fabric_api = 0.141.3+1.21.11
+fabric_api = 0.145.1+26.1

--- a/src/main/java/better_end_sky/mixin/CameraMixin.java
+++ b/src/main/java/better_end_sky/mixin/CameraMixin.java
@@ -1,0 +1,30 @@
+package better_end_sky.mixin;
+
+import net.minecraft.client.Camera;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
+import net.minecraft.world.level.Level;
+import org.jspecify.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static better_end_sky.Mod.hasBetterSky;
+import static better_end_sky.Mod.isDisabled;
+
+@Mixin(Camera.class)
+public class CameraMixin {
+
+    @Shadow
+    private @Nullable Level level;
+
+    @Inject(method = "extractRenderState", at = @At("TAIL"))
+    void nullifyMobEffects(CameraRenderState cameraState, float cameraEntityPartialTicks, CallbackInfo ci) {
+        if (!isDisabled() && level instanceof ClientLevel cLevel && hasBetterSky(cLevel)) {
+            cameraState.entityRenderState.doesMobEffectBlockSky = false;
+        }
+    }
+
+}

--- a/src/main/java/better_end_sky/mixin/FogRendererMixin.java
+++ b/src/main/java/better_end_sky/mixin/FogRendererMixin.java
@@ -2,47 +2,35 @@ package better_end_sky.mixin;
 
 import better_end_sky.util.BackgroundInfo;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.fog.FogData;
 import net.minecraft.client.renderer.fog.FogRenderer;
+import net.minecraft.network.chat.Component;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 import static better_end_sky.Mod.hasBetterSky;
 import static better_end_sky.Mod.isDisabled;
 
 @Mixin(FogRenderer.class)
 public abstract class FogRendererMixin {
-   /* @ModifyReturnValue(method = "computeFogColor", at = @At("RETURN"))
-    private static Vector4f onRender(Vector4f original) {
-        BackgroundInfo.fogColorRed = original.x;
-        BackgroundInfo.fogColorGreen = original.y;
-        BackgroundInfo.fogColorBlue = original.z;
+
+    @ModifyReturnValue(method = "setupFog", at = @At("RETURN"))
+    FogData modifyOutputFog(FogData original, @Local(argsOnly = true) ClientLevel level) {
+        if (!isDisabled() && hasBetterSky(level)) {
+            original.environmentalStart *= 0.8f;
+            original.renderDistanceStart *= 0.5f;
+        }
         return original;
-    }*/
-
-    @ModifyArg(method = "setupFog", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/fog/FogRenderer;updateBuffer(Ljava/nio/ByteBuffer;ILorg/joml/Vector4f;FFFFFF)V"), index = 3)
-    private static float modifyEnvStart(float f, @Local(argsOnly = true) ClientLevel level) {
-        if (isDisabled()) return f;
-        if (hasBetterSky(level)) {
-            return f * 0.8f;
-        }
-        return f;
-    }
-
-    @ModifyArg(method = "setupFog", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/fog/FogRenderer;updateBuffer(Ljava/nio/ByteBuffer;ILorg/joml/Vector4f;FFFFFF)V"), index = 5)
-    private static float modifyDistStart(float f, @Local(argsOnly = true) ClientLevel level) {
-        if (isDisabled()) return f;
-        if (hasBetterSky(level)) {
-            return f * 0.5f;
-        }
-        return f;
     }
 
     @ModifyExpressionValue(method = "computeFogColor", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/fog/environment/FogEnvironment;getModifiedDarkness(Lnet/minecraft/world/entity/LivingEntity;FF)F"))
-    private static float setDarknessMod(float original, @Local(argsOnly = true) ClientLevel world) {
+    private static float setDarknessMod(float original) {
         BackgroundInfo.darknessModifier = original;
         return original;
     }
+
 }

--- a/src/main/java/better_end_sky/mixin/LevelRendererMixin.java
+++ b/src/main/java/better_end_sky/mixin/LevelRendererMixin.java
@@ -2,7 +2,6 @@ package better_end_sky.mixin;
 
 import better_end_sky.render.EndSkyRenderState;
 import better_end_sky.render.EndSkyRenderer;
-import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
@@ -13,9 +12,11 @@ import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.client.renderer.SkyRenderer;
+import net.minecraft.client.renderer.chunk.ChunkSectionsToRender;
+import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.server.packs.resources.ResourceManager;
 import org.jetbrains.annotations.Nullable;
-import org.joml.Matrix4f;
+import org.joml.Matrix4fc;
 import org.joml.Vector4f;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -29,6 +30,7 @@ import static better_end_sky.Mod.isDisabled;
 
 @Mixin(LevelRenderer.class)
 public class LevelRendererMixin {
+
     @Shadow
     private @Nullable ClientLevel level;
     @Unique
@@ -42,32 +44,27 @@ public class LevelRendererMixin {
     }
 
     @Inject(method = "renderLevel", at = @At("HEAD"))
-    public void renderHeadHook(GraphicsResourceAllocator graphicsResourceAllocator, DeltaTracker deltaTracker, boolean bl, Camera camera, Matrix4f matrix4f, Matrix4f positionMatrix, Matrix4f matrix4f3, GpuBufferSlice gpuBufferSlice, Vector4f vector4f, boolean bl2, CallbackInfo ci, @Local(argsOnly = true, ordinal = 1) LocalBooleanRef fogCheck) {
+    public void renderHeadHook(GraphicsResourceAllocator resourceAllocator, DeltaTracker deltaTracker, boolean renderOutline, CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog, Vector4f fogColor, boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender, CallbackInfo ci, @Local(argsOnly = true, ordinal = 1) LocalBooleanRef fogCheck) {
         if (!isDisabled() && hasBetterSky(level)) {
             fogCheck.set(true);
         }
+    }
+
+    @Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/state/level/LevelRenderState;reset()V"))
+    public void renderTailHook(GraphicsResourceAllocator resourceAllocator, DeltaTracker deltaTracker, boolean renderOutline, CameraRenderState cameraState, Matrix4fc modelViewMatrix, GpuBufferSlice terrainFog, Vector4f fogColor, boolean shouldRenderSky, ChunkSectionsToRender chunkSectionsToRender, CallbackInfo ci, @Local(argsOnly = true, ordinal = 1) LocalBooleanRef fogCheck) {
         better_end_sky$EndSkyRenderStat.reset();
     }
 
-    @Inject(method = "renderLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/SkyRenderer;extractRenderState(Lnet/minecraft/client/multiplayer/ClientLevel;FLnet/minecraft/client/Camera;Lnet/minecraft/client/renderer/state/SkyRenderState;)V"))
-    public void extractEndSkyRenderState(GraphicsResourceAllocator graphicsResourceAllocator, DeltaTracker deltaTracker, boolean bl, Camera camera, Matrix4f matrix4f, Matrix4f matrix4f2, Matrix4f matrix4f3, GpuBufferSlice gpuBufferSlice, Vector4f vector4f, boolean bl2, CallbackInfo ci) {
+    @Inject(method = "extractLevel", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/SkyRenderer;extractRenderState(Lnet/minecraft/client/multiplayer/ClientLevel;FLnet/minecraft/client/Camera;Lnet/minecraft/client/renderer/state/level/SkyRenderState;)V"))
+    public void extractEndSkyRenderState(DeltaTracker deltaTracker, Camera camera, float deltaPartialTick, CallbackInfo ci) {
         better_end_sky$EndSkyRenderer.extractRenderState(level, better_end_sky$EndSkyRenderStat);
     }
 
-    @WrapWithCondition(method = "method_62215", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/SkyRenderer;renderEndSky()V"))
+    @WrapWithCondition(method = "lambda$addSkyPass$0", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/SkyRenderer;renderEndSky()V"))
     private static boolean renderEndSky(SkyRenderer instance) {
         if (isDisabled()) return true;
         better_end_sky$EndSkyRenderer.render(better_end_sky$EndSkyRenderStat);
         return false;
-    }
-
-    @ModifyReturnValue(method = "doesMobEffectBlockSky", at = @At("RETURN"))
-    boolean nullifyMobEffects(boolean original, Camera camera) {
-        if (isDisabled()) return original;
-        if (hasBetterSky(level)) {
-            return false;
-        }
-        return original;
     }
 
     @Inject(method = "onResourceManagerReload", at = @At("TAIL"))

--- a/src/main/java/better_end_sky/render/EndSkyRenderer.java
+++ b/src/main/java/better_end_sky/render/EndSkyRenderer.java
@@ -73,7 +73,7 @@ public class EndSkyRenderer implements AutoCloseable {
         nebula2 = buildBuffer(40, 60, 10, 14151, this::makeFarFog);
         horizon = buildBufferHorizon();
 
-        RandomSource random = RandomSource.createNewThreadLocalInstance();
+        RandomSource random = RandomSource.createThreadLocalInstance();
         axis1 = new Vector3f(random.nextFloat(), random.nextFloat(), random.nextFloat());
         axis2 = new Vector3f(random.nextFloat(), random.nextFloat(), random.nextFloat());
         axis3 = new Vector3f(random.nextFloat(), random.nextFloat(), random.nextFloat());
@@ -96,7 +96,7 @@ public class EndSkyRenderer implements AutoCloseable {
     }
 
     public void extractRenderState(Level world, EndSkyRenderState state) {
-        state.time = ((world.getDayTime() + client.getDeltaTracker().getRealtimeDeltaTicks()) % 360000) * 0.000017453292f;
+        state.time = ((world.getDefaultClockTime() + client.getDeltaTracker().getRealtimeDeltaTicks()) % 360000) * 0.000017453292f;
         state.darknessModifier = 1F - BackgroundInfo.darknessModifier;
     }
 
@@ -388,4 +388,5 @@ public class EndSkyRenderer implements AutoCloseable {
         stars3.close();
         stars4.close();
     }
+
 }

--- a/src/main/resources/better_end_sky.mixins.json
+++ b/src/main/resources/better_end_sky.mixins.json
@@ -4,6 +4,7 @@
   "package": "better_end_sky.mixin",
   "compatibilityLevel": "JAVA_17",
   "client": [
+    "CameraMixin",
     "FogRendererMixin",
     "LevelRendererMixin"
   ],

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,7 +23,7 @@
 
   "depends": {
     "fabricloader": "*",
-    "fabric": "*",
+    "fabric-api": "*",
     "minecraft": ">=1.21.10",
     "java": ">=17"
   }


### PR DESCRIPTION
The 26.1 port.
Notable Changes:
- Many gradle changes, Since 26.1 has no more mappings and is on java 25.
- `.createNewThreadLocalInstance()` -> `.createThreadLocalInstance()`
- `world.getDayTime()` was deleted so we now use the native world clock (`world.getDefaultClockTime()`)
- `doesMobEffectBlockSky()` was removed so `Camera.extractRenderState()` mixin was made
- `FogRendererMixin` got Simplified